### PR TITLE
Atomic pickle writing to avoid errors during parallel tests.

### DIFF
--- a/potodo/cache.py
+++ b/potodo/cache.py
@@ -1,4 +1,5 @@
 import logging
+from tempfile import NamedTemporaryFile
 import os
 import pickle
 from pathlib import Path
@@ -35,6 +36,9 @@ def set_cache_content(
 ) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     data = {"version": VERSION, "args": cache_args, "data": obj}
-    with open(path, "wb") as handle:
-        pickle.dump(data, handle)
+    with NamedTemporaryFile(
+        mode="wb", delete=False, dir=str(Path(path).parent), prefix=Path(path).name
+    ) as tmp:
+        pickle.dump(data, tmp)
+    os.rename(tmp.name, path)
     logging.debug("Set cache to %s", path)


### PR DESCRIPTION
This avoids:
```
  File "/home/mdk/clones/potodo/potodo/cache.py", line 20, in get_cache_file_content
    data = pickle.load(handle)
EOFError: Ran out of input
```
during `tox -p all`.