### PR TITLE
display total completion

### DIFF
--- a/potodo/__init__.py
+++ b/potodo/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Jules Lasne"""
 __email__ = "jules.lasne@gmail.com"
-__version__ = "0.17.3"
+__version__ = "0.17.4"

--- a/potodo/potodo.py
+++ b/potodo/potodo.py
@@ -165,6 +165,8 @@ def exec_potodo(
         else:
             exit()
     else:
+        total_translated: int = 0
+        total_entries: int = 0
         po_files_and_dirs = get_po_stats_from_repo_or_cache(
             path, exclude, cache_args, ignore_matches, no_cache
         )
@@ -205,6 +207,9 @@ def exec_potodo(
             else:
                 print_dir_stats(directory_name, buffer, folder_stats, printed_list)
 
+            total_translated += folder_stats["translated"]
+            total_entries += folder_stats["total"]
+
         if json_format:
             print(
                 json.dumps(
@@ -215,6 +220,9 @@ def exec_potodo(
                     default=json_dateconv,
                 )
             )
+        else:
+            total_completion = 100 * total_translated / total_entries
+            print(f"\n\n# TOTAL ({total_completion:.2f}% done)\n")
 
 
 def buffer_add(


### PR DESCRIPTION
On current 3.9 branch, displays:

```
# TOTAL (57.42% done)
```

Can be used for https://github.com/python/python-docs-fr/issues/1291 and https://github.com/python/python-docs-fr/issues/1051