### PR TITLE
Fix potodo regex / python-docs-fr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       rev: stable
       hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3
   -   repo: https://github.com/asottile/reorder_python_imports
       rev: v1.9.0
       hooks:

--- a/potodo/__init__.py
+++ b/potodo/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Jules Lasne"""
 __email__ = "jules.lasne@gmail.com"
-__version__ = "0.21.1"
+__version__ = "0.21.2"

--- a/potodo/github.py
+++ b/potodo/github.py
@@ -77,7 +77,7 @@ def _get_reservation_list(repo_path: Path) -> Dict[str, Tuple[Any, Any]]:
 
     for issue in issues:
         # Maybe find a better way for not using python 3.8 ?
-        yes = re.search(r"\w*/\w*\.po", issue["title"])
+        yes = re.search(r"\w*/(\w|\.)*\.po", issue["title"])
         if yes:
             creation_date = datetime.strptime(
                 issue["created_at"].split("T")[0], "%Y-%m-%d"


### PR DESCRIPTION
Original issue: https://github.com/python/python-docs-fr/issues/1834#issuecomment-1088358021

In 3 parts:

1. changes to `.pre-commit-config.yaml` following this issue : https://github.com/pre-commit/pre-commit/issues/1375
2. bumping the version as mentionned in the README : `potodo/__init__.py`
3. the actual regex which should work now in `potodo/github.py`

I am not sure about the first two. 

The actual change - the regex - seems to work and I've double-checked with https://regexr.com/ ?

Let me know if there is anything. 