### PR TITLE
Modify the github title regex to catch dashes in filenames

### DIFF
--- a/potodo/github.py
+++ b/potodo/github.py
@@ -77,7 +77,7 @@ def _get_reservation_list(repo_path: Path) -> Dict[str, Tuple[Any, Any]]:
 
     for issue in issues:
         # Maybe find a better way for not using python 3.8 ?
-        yes = re.search(r"\w*/(\w|\.)*\.po", issue["title"])
+        yes = re.search(r"\w*/[\w\-\.]*\.po", issue["title"])
         if yes:
             creation_date = datetime.strptime(
                 issue["created_at"].split("T")[0], "%Y-%m-%d"


### PR DESCRIPTION
Potodo doesn't seem to like dashes on filenames when looking for reservation issues on Github. (e.g. python/python-docs-fr#1884). This commit adds the dash to the regex.