### PR TITLE
Update CI tests

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run tox
-        run: tox -q -p all -e ${{ matrix.tox.env }}
+        run: tox -q -p all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
     name: Run tox on ${{ matrix.os }} for Python ${{ matrix.tox.py_version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         tox:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         os: [ubuntu-latest, macos-latest]
-        tox:
+        py_version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        include:
           - py_version: '3.6'
             env: py36
           - py_version: '3.7'
             env: py37
           - py_version: '3.8'
-            env: py38,flake8,mypy,black
+            env: py38
           - py_version: '3.9'
             env: py39
           - py_version: '3.10'
@@ -43,4 +45,4 @@ jobs:
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run tox
-        run: tox -q -p all
+        run: tox -q -p all -e ${{ matrix.tox.env }},flake8,mypy,black

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py_version }}
-          cache: 'pip'
-          cache-dependency-path: |
-            **/setup.cfg
-            **/requirements*.txt
-            .tox
+      - uses: actions/cache@v3
+        with:
+          path: .tox
+          key: ${{ matrix.os }}-${{ matrix.tox.python-version }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    name: Run tox on ${{ matrix.os }} for Python ${{ matrix.tox.py_version }}
+    name: Run tox on ${{ matrix.os }} for Python ${{ matrix.py_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.tox.py_version }}
+          python-version: ${{ matrix.py_version }}
           cache: 'pip'
           cache-dependency-path: |
             **/setup.cfg
@@ -45,4 +45,4 @@ jobs:
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run tox
-        run: tox -q -p all -e ${{ matrix.tox.env }},flake8,mypy,black
+        run: tox -q -p all -e ${{ matrix.env }},flake8,mypy,black

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,15 +24,20 @@ jobs:
             env: py38,flake8,mypy,black
           - py_version: '3.9'
             env: py39
+          - py_version: '3.10'
+            env: py310
+          - py_version: '3.11'
+            env: py311
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.tox.py_version }}
-      - uses: actions/cache@v2
-        with:
-          path: .tox
-          key: ${{ matrix.os }}-${{ matrix.tox.python-version }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements-dev.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/setup.cfg
+            **/requirements*.txt
+            .tox
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run tox

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ skip_covered = True
 show_missing = True
 
 [tox]
-envlist = py3{6,7,8,9,10}, flake8, mypy, black, coverage
+envlist = py3{6,7,8,9,10,11}, flake8, mypy, black, coverage
 skip_missing_interpreters = True
 
 [testenv]
@@ -24,7 +24,7 @@ setenv =
   COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 
 [testenv:coverage]
-depends = py38, py39, py310
+depends = py38, py39, py310, py311
 parallel_show_output = True
 skip_install = True
 setenv = COVERAGE_FILE={toxworkdir}/.coverage


### PR DESCRIPTION
I started with some GitHub Actions versions update and went on fixing stuff and enabling others, so I'm submitting for you consideration and see if anything else should be changed.

Heads up: errors popped up.

Summary of my changes:
- Updated actions/checkout and actions/setup-python to latest versions (post-nodejs v12 deprecation in github actions)
- Enabled added workflow_dispatch even trigger (allows manual start of the test), disabled fail-fast (run all matrix strategies, do not cancel all if one fail), enabled max-parallel 5 (to not run all matrix combinations at once)
- Enable Python 3.11 in tox and CI to pop up errors, and looks like I found
- Enable Python 3.10 in CI (was in tox already)
- Reorganize matrix.tox values; GitHub workflow editor was complaining that "matrix values must contain primitive values", so replaced 'tox' (py_version and env) with 'py_version' including 'env'
- Run flake8, mypy and black envs in all Python versions, instead of Python 3.8 only

Issues brought up:
- `ubuntu-latest` image (now 22.04) does not support Python 3.6 — note this doesn't affect `macos-latest` (yet);
- flake8 fails in all but Python 3.7 and 3.6 (only macos-latest due to above issue)
- Python 3.11 fails in "test_exclude_directory" test (both ubuntu and macos)

Error outputs:
<details>
<summary>Click for flake8 error output.</summary>
<pre>
 ERROR: invocation failed (exit code 1), logfile: /home/runner/work/Potodo/Potodo/.tox/flake8/log/flake8-0.log
================================== log start ===================================
Traceback (most recent call last):
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/bin/flake8", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
                                 ^^^^^^^^^^^^^^^^
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/options/parse_args.py", line 53, in parse_args
    opts = aggregator.aggregate_options(option_manager, cfg, cfg_dir, rest)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/options/aggregator.py", line 30, in aggregate_options
    parsed_config = config.parse_config(manager, cfg, cfg_dir)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Potodo/Potodo/.tox/flake8/lib/python3.11/site-packages/flake8/options/config.py", line 131, in parse_config
    raise ValueError(
ValueError: Error code '#' supplied to 'extend-ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'
ERROR: InvocationError for command /home/runner/work/Potodo/Potodo/.tox/flake8/bin/flake8 tests/ potodo/ (exited with code 1)
</pre>
</details>

<details>
<summary>Click for py311 error output.</summary>
<pre>
ERROR: invocation failed (exit code 1), logfile: /home/runner/work/Potodo/Potodo/.tox/py311/log/py311-0.log
================================== log start ===================================
============================= test session starts ==============================
platform linux -- Python 3.11.0, pytest-7.2.0, pluggy-1.0.0
cachedir: .tox/py311/.pytest_cache
rootdir: /home/runner/work/Potodo/Potodo
collected 20 items

tests/test_exclude.py ..F.                                               [ 20%]
tests/test_potodo.py ..                                                  [ 30%]
tests/test_potodo_args_errors.py .....                                   [ 55%]
tests/test_potodo_default_args.py .........                              [100%]

=================================== FAILURES ===================================
____________________________ test_exclude_directory ____________________________

capsys = <_pytest.capture.CaptureFixture object at 0x7fb6fa785c10>
base_config = {'above': 0, 'below': 100, 'counts': False, 'exclude': ['excluded/*'], ...}

    def test_exclude_directory(capsys, base_config):
        base_config["exclude"] = ["excluded/*"]
>       exec_potodo(**base_config)

tests/test_exclude.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
potodo/potodo.py:203: in exec_potodo
    non_interactive_output(
potodo/potodo.py:88: in non_interactive_output
    po_files_and_dirs = get_po_stats_from_repo_or_cache(path, ignore_matches, no_cache)
potodo/po_file.py:82: in get_po_stats_from_repo_or_cache
    all_po_files: List[Path] = [
potodo/po_file.py:83: in <listcomp>
    file for file in repo_path.rglob("*.po") if not ignore_matches(str(file))
potodo/potodo.py:155: in <lambda>
    return lambda file_path: any(r.match(file_path) for r in rules)
potodo/potodo.py:155: in <genexpr>
    return lambda file_path: any(r.match(file_path) for r in rules)
.tox/py311/lib/python3.11/site-packages/gitignore_parser.py:147: in match
    if re.search(self.regex, rel_path):
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/re/__init__.py:176: in search
    return _compile(pattern, flags).search(string)
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/re/__init__.py:294: in _compile
    p = _compiler.compile(pattern, flags)
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/re/_compiler.py:743: in compile
    p = _parser.parse(p, flags)
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/re/_parser.py:980: in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/re/_parser.py:455: in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

source = <re._parser.Tokenizer object at 0x7fb6fa7b6a10>
state = <re._parser.State object at 0x7fb6fa7c00d0>, verbose = 0, nested = 1
first = True

    def _parse(source, state, verbose, nested, first=False):
        # parse a simple pattern
        subpattern = SubPattern(state)
    
                                import warnings
                                warnings.warn(
                                    "bad character in group name %s at position %d" %
                                    (repr(condname) if source.istext else ascii(condname),
                                     source.tell() - len(condname) - 1),
                                    DeprecationWarning, stacklevel=nested + 6
                                )
                        state.checklookbehindgroup(condgroup, source)
                        item_yes = _parse(source, state, verbose, nested + 1)
                        if source.match("|"):
                            item_no = _parse(source, state, verbose, nested + 1)
                            if source.next == "|":
                                raise source.error("conditional backref with more than two branches")
                        else:
                            item_no = None
                        if not source.match(")"):
                            raise source.error("missing ), unterminated subpattern",
                                               source.tell() - start)
                        subpatternappend((GROUPREF_EXISTS, (condgroup, item_yes, item_no)))
                        continue
    
                    elif char == ">":
                        # non-capturing, atomic group
                        capture = False
                        atomic = True
                    elif char in FLAGS or char == "-":
                        # flags
                        flags = _parse_flags(source, state, char)
                        if flags is None:  # global flags
                            if not first or subpattern:
>                               raise source.error('global flags not at the start '
                                                   'of the expression',
                                                   source.tell() - start)
E                               re.error: global flags not at the start of the expression at position 1

/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/re/_parser.py:841: error
=========================== short test summary info ============================
FAILED tests/test_exclude.py::test_exclude_directory - re.error: global flags...
========================= 1 failed, 19 passed in 6.79s =========================
ERROR: InvocationError for command /home/runner/work/Potodo/Potodo/.tox/py311/bin/coverage run -m pytest (exited with code 1)

=================================== log end ====================================
✖ FAIL py311 in 24.09 seconds
</pre>
</details>

(also attaching because the output was HTML-formatted a bit: [py311.txt](https://github.com/AFPy/Potodo/files/10104317/py311.txt))

Ideas:
- Want me to add 3.12-dev as well, to spot issues before next Python release?
- Drop Python 3.6 (which is already EOL) tests ? (if yes, I'd recommend updating setup.cfg as well)