### PR TITLE
gitea usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,23 @@ pip install potodo
 ## Usage example
 
 ```
-usage: potodo [-h] [-p path] [-e path [path ...]] [-a X] [-b X] [-f] [-o] [-n] [-c] [-j] [--exclude-fuzzy] [--exclude-reserved] [--only-reserved] [--show-reservation-dates] [--no-cache] [-i] [-l] [--version] [-v]
+usage: potodo [-h] [-p path] [-e path [path ...]] [-a X] [-b X] [-f] [-o] [-u API_URL] [-n] [-c] [-j] [--exclude-fuzzy] [--exclude-reserved]
+              [--only-reserved] [--show-reservation-dates] [--no-cache] [-i] [-l] [--version] [-v]
 
 List and prettify the po files left to translate.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -p path, --path path  execute Potodo in path
   -e path [path ...], --exclude path [path ...]
-                        exclude from search
+                        gitignore-style patterns to exclude from search.
   -a X, --above X       list all TODOs above given X% completion
   -b X, --below X       list all TODOs below given X% completion
   -f, --only-fuzzy      print only files marked as fuzzys
-  -o, --offline         don't perform any fetching to GitHub/online
+  -o, --offline         don't perform any fetching to GitHub/Gitea/online
+  -u API_URL, --api-url API_URL
+                        API URL to retrieve reservation tickets (https://api.github.com/repos/ORGANISATION/REPOSITORY/issues?state=open or
+                        https://git.afpy.org/api/v1/repos/ORGANISATION/REPOSITORY/issues?state=open&type=issues)
   -n, --no-reserved     don't print info about reserved files
   -c, --counts          render list with the count of remaining entries (translate or review) rather than percentage done
   -j, --json            format output as JSON
@@ -54,7 +58,8 @@ optional arguments:
                         show issue creation dates
   --no-cache            Disables cache (Cache is disabled when files are modified)
   -i, --interactive     Activates the interactive menu
-  -l, --matching-files  Suppress normal output; instead print the name of each matching po file from which output would normally have been printed.
+  -l, --matching-files  Suppress normal output; instead print the name of each matching po file from which output would normally have been
+                        printed.
   --version             show program's version number and exit
   -v, --verbose         Increases output verbosity
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install potodo
 ## Usage example
 
 ```
-usage: potodo [-h] [-p path] [-e path [path ...]] [-a X] [-b X] [-f] [-o] [-u API_URL] [-n] [-c] [-j] [--exclude-fuzzy] [--exclude-reserved]
+usage: potodo [-h] [-p path] [-e path [path ...]] [-a X] [-b X] [-f] [-u API_URL] [-n] [-c] [-j] [--exclude-fuzzy] [--exclude-reserved]
               [--only-reserved] [--show-reservation-dates] [--no-cache] [-i] [-l] [--version] [-v]
 
 List and prettify the po files left to translate.
@@ -44,7 +44,6 @@ options:
   -a X, --above X       list all TODOs above given X% completion
   -b X, --below X       list all TODOs below given X% completion
   -f, --only-fuzzy      print only files marked as fuzzys
-  -o, --offline         don't perform any fetching to GitHub/Gitea/online
   -u API_URL, --api-url API_URL
                         API URL to retrieve reservation tickets (https://api.github.com/repos/ORGANISATION/REPOSITORY/issues?state=open or
                         https://git.afpy.org/api/v1/repos/ORGANISATION/REPOSITORY/issues?state=open&type=issues)

--- a/potodo/arguments_handling.py
+++ b/potodo/arguments_handling.py
@@ -13,7 +13,6 @@ def check_args(
     above: int,
     verbose: int,
     only_fuzzy: bool,
-    offline: bool,
     hide_reserved: bool,
     counts: bool,
     json_format: bool,

--- a/potodo/forge_api.py
+++ b/potodo/forge_api.py
@@ -46,7 +46,9 @@ def _get_reservation_list(api_url: str) -> Dict[str, Tuple[Any, Any]]:
 
 
 def get_issue_reservations(
-    offline: bool, hide_reserved: bool, api_url: str,
+    offline: bool,
+    hide_reserved: bool,
+    api_url: str,
 ) -> Dict[str, Tuple[Any, Any]]:
     """Retrieve info about reservation if needed."""
 

--- a/potodo/forge_api.py
+++ b/potodo/forge_api.py
@@ -46,13 +46,12 @@ def _get_reservation_list(api_url: str) -> Dict[str, Tuple[Any, Any]]:
 
 
 def get_issue_reservations(
-    offline: bool,
     hide_reserved: bool,
     api_url: str,
 ) -> Dict[str, Tuple[Any, Any]]:
     """Retrieve info about reservation if needed."""
 
-    if not offline and not hide_reserved:
+    if api_url and not hide_reserved:
         logging.info("Getting issue reservations from git.afpy.org")
         # If the reservations are to be displayed, then get them
         issue_reservations = _get_reservation_list(api_url)

--- a/potodo/potodo.py
+++ b/potodo/potodo.py
@@ -66,7 +66,6 @@ def non_interactive_output(
     above: int,
     below: int,
     only_fuzzy: bool,
-    offline: bool,
     hide_reserved: bool,
     counts: bool,
     json_format: bool,
@@ -83,7 +82,7 @@ def non_interactive_output(
     dir_stats: List[Any] = []
     # Initialize the arguments
     if api_url:
-        issue_reservations = get_issue_reservations(offline, hide_reserved, api_url)
+        issue_reservations = get_issue_reservations(hide_reserved, api_url)
     else:
         issue_reservations = {}
 
@@ -165,7 +164,6 @@ def exec_potodo(
     above: int,
     below: int,
     only_fuzzy: bool,
-    offline: bool,
     hide_reserved: bool,
     counts: bool,
     json_format: bool,
@@ -186,7 +184,6 @@ def exec_potodo(
     :param above: The above threshold
     :param below: The below threshold
     :param only_fuzzy: Should only fuzzies be printed
-    :param offline: Will not connect to internet
     :param hide_reserved: Will not show the reserved files
     :param counts: Render list with counts not percentage
     :param json_format: Format output as JSON.
@@ -212,7 +209,6 @@ def exec_potodo(
             above,
             below,
             only_fuzzy,
-            offline,
             hide_reserved,
             counts,
             json_format,
@@ -382,13 +378,6 @@ def main() -> None:
         dest="only_fuzzy",
         action="store_true",
         help="print only files marked as fuzzys",
-    )
-
-    parser.add_argument(
-        "-o",
-        "--offline",
-        action="store_true",
-        help="don't perform any fetching to GitHub/Gitea/online",
     )
 
     parser.add_argument(

--- a/potodo/potodo.py
+++ b/potodo/potodo.py
@@ -396,7 +396,7 @@ def main() -> None:
         "--api-url",
         help=(
             "API URL to retrieve reservation tickets (https://api.github.com/repos/ORGANISATION/REPOSITORY/issues?state=open or https://git.afpy.org/api/v1/repos/ORGANISATION/REPOSITORY/issues?state=open&type=issues)"
-        )
+        ),
     )
 
     parser.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ def base_config(repo_dir):
         "only_fuzzy": False,
         "hide_reserved": False,
         "counts": False,
-        "offline": True,
         "is_interactive": False,
         "exclude_fuzzy": False,
         "only_reserved": False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,4 +27,5 @@ def base_config(repo_dir):
         "no_cache": True,
         "matching_files": False,
         "json_format": False,
+        "api_url": "",
     }


### PR DESCRIPTION
Désolé pour le push involontaire de la première partie… Je viens de mettre à jour les tests et le usage dans le README.

Comme @JulienPalard le proposait, potodo prend maintenant une URL d'API (GitHub ou Gitea) permettant plus de flexibilité par la suite.